### PR TITLE
Added g_type_init for older glib versions

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -94,6 +94,10 @@ int main(int argc, char** argv) {
         }
     }
 
+    #if !GLIB_CHECK_VERSION(2, 35, 0)
+        g_type_init();
+    #endif
+
     g_set_application_name("spop " SPOP_VERSION);
     g_set_prgname("spop");
 


### PR DESCRIPTION
Hello!

g_type_init is deprecated in Glib since 2.36, but is needed for older versions. Without this init call, the program will crash with following error message: 

GLib-GObject 2013-07-28 00:36:35 [CRIT] /build/glib2.0-AWe8Zn/glib2.0-2.33.12+really2.32.4/./gobject/gtype.c:2722: You forgot to call g_type_init()
GLib 2013-07-28 00:36:35 [CRIT] g_once_init_leave: assertion `result != 0' failed
GLib-GObject 2013-07-28 00:36:35 [CRIT] g_object_new: assertion`G_TYPE_IS_OBJECT (object_type)' failed

I dont know if you want to support older versions of 3pp's, but the Wheezy packages comes with an older version. 
http://packages.debian.org/wheezy/libglib2.0-0
