### PR TITLE
Make OSS output device configurable

### DIFF
--- a/plugins/oss.c
+++ b/plugins/oss.c
@@ -37,6 +37,7 @@
 #include <unistd.h>
 
 #include "audio.h"
+#include "config.h"
 
 static int g_oss_fd = -1;
 static struct pollfd g_pfd;
@@ -45,9 +46,13 @@ static GMutex g_oss_mutex;
 
 /* "Private" functions, used to set up the OSS device */
 static void oss_open() {
+    const gchar *oss_dev;
+
+    oss_dev = config_get_string_opt_group("oss", "device", "/dev/dsp");
+
     /* Open the device */
     g_debug("Opening OSS device");
-    g_oss_fd = open("/dev/dsp", O_WRONLY);
+    g_oss_fd = open(oss_dev, O_WRONLY);
     if (g_oss_fd == -1)
         g_error("Can't open OSS device: %s", g_strerror(errno));
 

--- a/spopd.conf.sample
+++ b/spopd.conf.sample
@@ -88,3 +88,7 @@ password = PASSWORD
 # List of effets to apply to the audio output, with their parameters. See `man
 # soxeffects' for details.
 #effects = gain -3; pad 0 3; reverb
+
+[oss]
+# Device to use for OSS output. Default is /dev/dsp
+#device = /dev/dsp


### PR DESCRIPTION
Instead of hardcoding /dev/dsp for the OSS output plugin, make this
configurable through the config file.
