### PR TITLE
Add uimage command to get cover image of a track or album

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ official Spotify client. Then, you will be able to use the following commands:
   only)
 - `uplay uri`: replace the contents of the queue with the given Spotify URI
   (playlist, track or album only) and start playing
+- `uimage uri`: get the cover image for given uri (base64-encoded JPEG image).
+  Uri must be an track or album uri.
+- `uimage uri size`: get the cover image for given uri (base64-encoded JPEG
+  image).  Uri must be an track or album uri. Use 0 for normal size, 1 for
+  large size and 2 for small size.
 
 ---
 

--- a/src/commands.h
+++ b/src/commands.h
@@ -84,6 +84,8 @@ gboolean image(command_context* ctx);
 gboolean uri_info(command_context* ctx, sp_link* lnk);
 gboolean uri_add(command_context* ctx, sp_link* lnk);
 gboolean uri_play(command_context* ctx, sp_link* lnk);
+gboolean uri_image(command_context* ctx, sp_link* lnk);
+gboolean uri_image_size(command_context* ctx, sp_link* lnk, guint size);
 
 gboolean search(command_context* ctx, const gchar* query);
 

--- a/src/interface.c
+++ b/src/interface.c
@@ -97,6 +97,8 @@ static command_full_descriptor g_commands[] = {
     { "uinfo",   CT_FUNC, { uri_info, {CA_URI, CA_NONE}}},
     { "uadd",    CT_FUNC, { uri_add,  {CA_URI, CA_NONE}}},
     { "uplay",   CT_FUNC, { uri_play, {CA_URI, CA_NONE}}},
+    { "uimage",  CT_FUNC, { uri_image, {CA_URI, CA_NONE}}},
+    { "uimage",  CT_FUNC, { uri_image_size, {CA_URI, CA_INT}}},
 
     { "search",  CT_FUNC, { search, {CA_STR, CA_NONE}}},
 

--- a/src/spotify.c
+++ b/src/spotify.c
@@ -503,6 +503,10 @@ gboolean track_available(sp_track* track) {
     return (sp_track_get_availability(g_session, track) == SP_TRACK_AVAILABILITY_AVAILABLE);
 }
 
+sp_image* image_id_get_image(const void* img_id) {
+  return sp_image_create(g_session, img_id);
+}
+
 sp_image* track_get_image(sp_track* track) {
     sp_album* alb = NULL;
     sp_image* img = NULL;

--- a/src/spotify.h
+++ b/src/spotify.h
@@ -73,6 +73,8 @@ sp_image* track_get_image(sp_track* track);
 gboolean track_get_image_data(sp_track* track, gpointer* data, gsize* len);
 gboolean track_get_image_file(sp_track* track, gchar** filename);
 
+sp_image* image_id_get_image(const void* img_id);
+
 /* Browsing */
 sp_albumbrowse* albumbrowse_create(sp_album* album, albumbrowse_complete_cb* callback, gpointer userdata);
 sp_artistbrowse* artistbrowse_create(sp_artist* artist, artistbrowse_complete_cb* callback, gpointer userdata);


### PR DESCRIPTION
To get a cover image of a track the track, the album and the image must be loaded. libspotify might load these data asynchronous. This could lead some headache.

I've tried to get the async loading/polling/waiting as readable as possible with extracted methods `_uri_image_cb_*()`, introduced callback data struct `uri_image_cb_data`, and enum `uri_image_cb_result_type`. Further, I've tried to avoid `goto` statements. So the new code is similar to existing uri commands but different. Hope this is fine.

Please add comments if any changes should be done before merging.
