### PR TITLE
uimage command size fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ official Spotify client. Then, you will be able to use the following commands:
 - `uimage uri`: get the cover image for given uri (base64-encoded JPEG image).
   Uri must be an track or album uri.
 - `uimage uri size`: get the cover image for given uri (base64-encoded JPEG
-  image).  Uri must be an track or album uri. Use 0 for normal size, 1 for
-  large size and 2 for small size.
+  image).  Uri must be an track or album uri. Use 0 for normal size (300px), 1
+  for small size (64px) and 2 for large size (640px).
 
 ---
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -1039,7 +1039,7 @@ static uri_image_cb_result_type _uri_image_cb_image(uri_image_cb_data* data) {
     }
 
     // fetch the cover image id
-    img_id = sp_album_cover(data->album, SP_IMAGE_SIZE_NORMAL);
+    img_id = sp_album_cover(data->album, data->size);
     if (!img_id) {
         g_debug("Image id not found");
         jb_add_string(ctx->jb, "error", "Image absent");


### PR DESCRIPTION
Consume size data from uri_image_cb_data struct for image data retrival
